### PR TITLE
[IOT-CLOUD]: Added Graphite and MQTT to Graphite adaptor

### DIFF
--- a/projects/iot-cloud/software/mqtt-to-graphite/Dockerfile
+++ b/projects/iot-cloud/software/mqtt-to-graphite/Dockerfile
@@ -1,0 +1,10 @@
+FROM python:3-alpine
+
+WORKDIR /usr/src/app
+
+COPY src/ .
+COPY config/ .
+
+RUN pip install --no-cache-dir -r requirements.txt
+
+CMD [ "python", "./mqtt-to-graphite.py" ]

--- a/projects/iot-cloud/software/mqtt-to-graphite/config/map
+++ b/projects/iot-cloud/software/mqtt-to-graphite/config/map
@@ -1,0 +1,54 @@
+#(@)mqtt2graphite map file
+
+# Each line has two OR three values in it. Values MUST no contain white
+# space.
+
+# First value:
+#	n 	payload contains a number (int or float) use that
+#	j	payload is JSON. Extract all keys with numeric values
+
+# Second value:
+#	Subscribe to this channel. MQTT wildcards (#) are allowed.
+
+# Third (optional) value:
+#	The MQTT topic is to be mapped to this key in Carbon (Graphite)
+#	Use periods as separators, just like Carbon expects them. If
+#	this value is not specified, the MQTT topic name will be used,
+#	with slashes (/) converted to dots (.)
+#	If the # character is present, it will be replaced by the
+#	MQTT topic name with the points converted to slashes
+
+# n	test/mosquitto/messages/load/received
+# n	test/mosquitto/messages/load/#
+
+# n	test/jp/j1
+
+# n	$SYS/broker/load/messages/received/1min		test.mosquitto.messages.load.received
+# n	$SYS/broker/load/messages/sent/1min		test.mosquitto.messages.load.sent
+
+# Will be sent to "homeautomation.sensor.temperature.bedroom"
+# n	sensor/temperature/bedroom	homeautomation.#
+
+# j	test/jp/j2
+
+# j	test/jp/j3					test.jp.json
+
+# The last line above means, subscribe to the MQTT topic of "test/jp/jp3",
+# extract JSON, and translate the topic to a the "test.jp.json.___" key.
+# Submitting an MQTT message payload of
+#
+#	{ "size":69,"temp": 89.3, "gas": " 88", "name": "JP Mens" }
+#
+# will produce the following Carbon entries:
+#
+#	test.jp.json.gas 88.000000 1363169729
+#	test.jp.json.temp 89.300000 1363169729
+#	test.jp.json.size 69.000000 1363169729
+
+j meshliumf958/#
+j meshliumfa30/#
+j verbund/ST1
+j citisim/raspberry/IoanaPiZero
+j citisim/pycom/ST1
+j seaforest/raspberrypi/ST1
+

--- a/projects/iot-cloud/software/mqtt-to-graphite/config/map
+++ b/projects/iot-cloud/software/mqtt-to-graphite/config/map
@@ -51,4 +51,5 @@ j verbund/ST1
 j citisim/raspberry/IoanaPiZero
 j citisim/pycom/ST1
 j seaforest/raspberrypi/ST1
+j lora/#
 

--- a/projects/iot-cloud/software/mqtt-to-graphite/src/mqtt-to-graphite.py
+++ b/projects/iot-cloud/software/mqtt-to-graphite/src/mqtt-to-graphite.py
@@ -1,0 +1,215 @@
+#!/usr/bin/env python
+
+__author__ = "Jan-Piet Mens"
+__copyright__ = "Copyright (C) 2013 by Jan-Piet Mens"
+
+import datetime
+import json
+import logging
+import os
+import signal
+import socket
+import sys
+import time
+
+import dateutil.parser as date_parser
+import paho.mqtt.client as paho
+
+MQTT_HOST = os.environ.get('MQTT_HOST', '127.0.0.1')
+MQTT_PORT = int(os.environ.get('MQTT_PORT', 1883))
+CARBON_SERVER = os.environ.get('CARBON_SERVER', '127.0.0.1')
+CARBON_PORT = int(os.environ.get('CARBON_PORT', 2003))
+CARBON_PREFIX = os.environ.get('CARBON_PREFIX', "mqtt")
+
+LOGFORMAT = '%(asctime)-15s %(message)s'
+
+DEBUG = os.environ.get('DEBUG', True)
+if DEBUG:
+    logging.basicConfig(level=logging.DEBUG, format=LOGFORMAT)
+else:
+    logging.basicConfig(level=logging.INFO, format=LOGFORMAT)
+
+client_id = "MQTT2Graphite_%d-%s" % (os.getpid(), socket.getfqdn())
+
+
+def cleanup(signum, frame):
+    '''Disconnect cleanly on SIGTERM or SIGINT'''
+
+    mqttc.publish("/clients/" + client_id, "Offline")
+    mqttc.disconnect()
+    logging.info("Disconnected from broker; exiting on signal %d", signum)
+    sys.exit(signum)
+
+
+def is_number(s):
+    '''Test whether string contains a number (leading/traling white-space is ok)'''
+
+    try:
+        float(s)
+        return True
+    except ValueError:
+        return False
+
+
+def on_connect(mosq, userdata, flags, rc):
+    logging.info("Connected to broker at %s as %s" % (MQTT_HOST, client_id))
+
+    mqttc.publish("/clients/" + client_id, "Online")
+
+    map = userdata['map']
+    for topic in map:
+        logging.debug("Subscribing to topic %s" % topic)
+        mqttc.subscribe(topic, 0)
+
+
+def on_message(mosq, userdata, msg):
+    sock = userdata['sock']
+    lines = []
+    now = datetime.datetime.now()
+
+    map = userdata['map']
+    # Find out how to handle the topic in this message: slurp through
+    # our map
+    for t in map:
+        if paho.topic_matches_sub(t, msg.topic):
+            # print "%s matches MAP(%s) => %s" % (msg.topic, t, map[t])
+
+            # Must we rename the received msg topic into a different
+            # name for Carbon? In any case, replace MQTT slashes (/)
+            # by Carbon periods (.)
+            (type, remap) = map[t]
+            if remap is None:
+                carbonkey = msg.topic.replace('/', '.')
+            else:
+                if '#' in remap:
+                    remap = remap.replace('#', msg.topic.replace('/', '.'))
+                carbonkey = remap.replace('/', '.')
+
+            if len(CARBON_PREFIX) > 0:
+                carbonkey = "{prefix}.{old_key}".format(prefix=CARBON_PREFIX,
+                                                        old_key=carbonkey)
+
+            logging.debug("CARBONKEY is [%s]" % carbonkey)
+
+            if type == 'n':
+                '''Number: obtain a float from the payload'''
+                try:
+                    number = float(msg.payload)
+                    lines.append("%s %f %d" % (carbonkey, number, int(now)))
+                except ValueError:
+                    logging.info("Topic %s contains non-numeric payload [%s]" %
+                                 (msg.topic, msg.payload))
+                    return
+
+            elif type == 'j':
+                '''JSON: try and load the JSON string from payload and use
+                   subkeys to pass to Carbon'''
+                try:
+                    data_time = now
+                    st = json.loads(msg.payload)
+                    if 'timestamp' in st:
+                        try:
+                            timestamp = st['timestamp']
+                            data_time = date_parser.parse(timestamp)
+                            logging.info('Extracted date {data_time} from timestamp "{timestamp}"'.format(
+                                data_time=str(data_time), timestamp=timestamp))
+
+                        except ValueError:
+                            # Invalid content of timestamp
+                            logging.info('Failed to extract date-time from "{}"'.format(timestamp))
+                            pass
+                        except OverflowError:
+                            logging.info('Failed to extract date-time from "{}"'.format(timestamp))
+                            pass
+
+                    for k in st:
+                        if is_number(st[k]) and k != 'id':
+                            lines.append("%s.%s %f %d" % (carbonkey, k, float(st[k]), data_time.timestamp()))
+                except Exception as e:
+                    logging.info("Topic %s -  there was an error parsing this payload as compliant JSON [%s]" %
+                                 (msg.topic, msg.payload))
+                    logging.debug(e)
+                    return
+
+            else:
+                logging.info("Unknown mapping key [%s]", type)
+                return
+
+            message = '\n'.join(lines) + '\n'
+            logging.debug("%s", message)
+
+            sock.send(message.encode())
+
+
+def on_subscribe(mosq, userdata, mid, granted_qos):
+    pass
+
+
+def on_disconnect(mosq, userdata, rc):
+    if rc == 0:
+        logging.info("Clean disconnection")
+    else:
+        logging.info("Unexpected disconnect (rc %s); reconnecting in 5 seconds" % rc)
+        time.sleep(5)
+
+
+def main():
+    logging.info("Starting %s" % client_id)
+    logging.info("INFO MODE")
+    logging.debug("DEBUG MODE")
+
+    map = {}
+    if len(sys.argv) > 1:
+        map_file = sys.argv[1]
+    else:
+        map_file = 'map'
+
+    f = open(map_file)
+    for line in f.readlines():
+        line = line.rstrip()
+        if len(line) == 0 or line[0] == '#':
+            continue
+        remap = None
+        try:
+            type, topic, remap = line.split()
+        except ValueError:
+            type, topic = line.split()
+
+        map[topic] = (type, remap)
+
+    try:
+        sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    except:
+        sys.stderr.write("Can't create TCP socket\n")
+        sys.exit(1)
+
+    try:
+        sock.connect((CARBON_SERVER, CARBON_PORT))
+    except:
+        sys.stderr.write("Failed to connect to Graphite")
+        sys.exit(-1)
+
+    userdata = {
+        'sock': sock,
+        'map': map,
+    }
+    global mqttc
+    mqttc = paho.Client(client_id, clean_session=True, userdata=userdata)
+    mqttc.on_message = on_message
+    mqttc.on_connect = on_connect
+    mqttc.on_disconnect = on_disconnect
+    mqttc.on_subscribe = on_subscribe
+
+    mqttc.will_set("clients/" + client_id, payload="Adios!", qos=0, retain=False)
+
+    mqttc.connect(MQTT_HOST, MQTT_PORT, 60)
+
+    signal.signal(signal.SIGTERM, cleanup)
+    signal.signal(signal.SIGINT, cleanup)
+
+    mqttc.loop_forever()
+
+
+if __name__ == '__main__':
+    main()
+

--- a/projects/iot-cloud/software/mqtt-to-graphite/src/requirements.txt
+++ b/projects/iot-cloud/software/mqtt-to-graphite/src/requirements.txt
@@ -1,0 +1,2 @@
+paho-mqtt==1.3.1
+python-dateutil==2.7.3


### PR DESCRIPTION
# PR description
Added Graphite and MQTT to Graphite middleware adaptor.

The new added software is based on jpmens's [mqtt2graphite](https://github.com/jpmens/mqtt2graphite).

I have improved it by:
- Changing Carbon UDP socket to TCP;
- Added special case for JSONs including timestamps;
- Added special case for ignoring id key.

# TODO's
- [ ] add depends statements in `stack.yml` for `mqttconn`
- [ ] squash **before** merge

# Supported formats

It supports both numeric-only messages (eg. `3.14`) and JSON formatted messages.
The default Carbon/Graphite key is obtained by replacing `/` with `.` in the MQTT message topic.
For JSON formatted messages, the name of the numeric key is appended as the final node of the Carbon key. Remapping is allowed by map config file.

For more details, see the comments in [map](https://github.com/beia/beialand/blob/mqtt-graphite/projects/iot-cloud/software/mqtt-to-graphite/config/map) config file.

# Current Power2SME/Citisim use-case

Our current use-case is to gather data from Libelium devices. In the current production configuration, we have the default topic and JSON format as:
- Topic `#MESHLIUM#/#ID_WASP#/#SENSOR#`
- JSON Template:
```
{
  "id": "#ID#",
  "id_wasp": "#ID_WASP#", 
  "id_secret": "#ID_SECRET#",
  "sensor": "#SENSOR#",
  "value": "#VALUE#",
  "timestamp": "#TS("c")#"
}
```

# Example of MQTT Message
Topic: `meshliumf958/SCP2/BAT`
Data: 
```
{
  "id": "64132",
  "id_wasp": "SCP2", 
  "id_secret": "42177063D9374202",
  "sensor": "BAT",
  "value": "7",
  "timestamp": "2018-06-05T18:02:20+03:00"
}
```

# Test-case suggestions
If you want to make a real-life test of this stack, you can replace MQTT_HOST with `82.78.81.188`. The broker running on it receives data from Libelium every ~10 minutes.

# Other remarks
- This is a code-review PR. Please ask before merging to master.
- The image is manually pushed to docker hub. Automatic building is pending to be set.