### PR TITLE
[IOT-CLOUD]: Isolation & Persistent config for Graphite

### DIFF
--- a/projects/iot-cloud/stack.yml
+++ b/projects/iot-cloud/stack.yml
@@ -5,6 +5,7 @@ services:
     image: vladwing/graphite
     volumes:
       - graphite:/opt/graphite/storage
+      - graphite_conf:/opt/graphite/conf
     networks:
      - graphite
 
@@ -55,6 +56,7 @@ services:
 
 volumes:
   graphite:
+  graphite_conf:
   grafana:
   mosca:
   redis:

--- a/projects/iot-cloud/stack.yml
+++ b/projects/iot-cloud/stack.yml
@@ -19,15 +19,6 @@ services:
     volumes:
       - grafana:/var/lib/grafana
 
-  statsd:
-    image: vladwing/statsd
-    environment:
-      GRAPHITE_HOST: 'graphite'
-    networks:
-     - graphite
-    ports:
-      - "8125:8125/udp"
-
   broker:
     image: beia/mqtt-broker
     volumes:

--- a/projects/iot-cloud/stack.yml
+++ b/projects/iot-cloud/stack.yml
@@ -3,16 +3,10 @@ version: '3.6'
 services:
   graphite:
     image: vladwing/graphite
-    ports:
-      - "2003:2003"
     volumes:
       - graphite:/opt/graphite/storage
-    environment:
-      VIRTUAL_HOST: 'graphite.beia.cloud,graphite.beia-telemetrie.ro,graphite.beia-consult.ro'
-      VIRTUAL_PORT: 80
     networks:
      - graphite
-     - proxy_net
 
   grafana:
     image: grafana/grafana


### PR DESCRIPTION
Changes:
- Unpublished Graphite (the data will be accessible through Grafana and we will feed data through MQTT only)
- Removed statsd
- Added volume for graphite config

The bootstrap problem for the new volume will be solved after the PR 1 on the image build repository (https://github.com/vladwing/docker/pull/1) will be merged.