### PR TITLE
[IOT-CLOUD]: Replaced mosca by emqtt

### DIFF
--- a/projects/iot-cloud/stack.yml
+++ b/projects/iot-cloud/stack.yml
@@ -90,9 +90,6 @@ services:
     ports:
      - "1883:1883"
     environment:
-      # VIRTUAL_HOST: 'emqtt-dashboard.beia-telemetrie.ro'
-      # VIRTUAL_PORT: 18083
-      # EMQ_LOADED_PLUGINS: 'emq_recon,emq_modules,emq_retainer,emq_dashboard'
       EMQ_LOADED_PLUGINS: 'emq_recon,emq_modules,emq_retainer'
     networks:
      - broker

--- a/projects/iot-cloud/stack.yml
+++ b/projects/iot-cloud/stack.yml
@@ -81,26 +81,22 @@ services:
       - postgres_password
 
   broker:
-    image: beia/mqtt-broker
+    image: beia/emqtt
     volumes:
-     - mosca:/db
+      - emqtt_data:/opt/emqttd/data
+      - emqtt_etc:/opt/emqttd/etc
+      - emqtt_lib:/opt/emqttd/lib
+      - emqtt_log:/opt/emqttd/log
     ports:
      - "1883:1883"
     environment:
-      VIRTUAL_HOST: 'mqtt.beia-consult.ro'
-      VIRTUAL_PORT: 80
-      REDIS_HOST: 'redis'
+      # VIRTUAL_HOST: 'emqtt-dashboard.beia-telemetrie.ro'
+      # VIRTUAL_PORT: 18083
+      # EMQ_LOADED_PLUGINS: 'emq_recon,emq_modules,emq_retainer,emq_dashboard'
+      EMQ_LOADED_PLUGINS: 'emq_recon,emq_modules,emq_retainer'
     networks:
-     - redis
      - broker
      - proxy_net
-
-  redis:
-    image: redis:alpine
-    networks:
-     - redis
-    volumes:
-     - redis:/data
 
   # MQTT -- Graphite Midleware
   mqtt2graphite:
@@ -134,15 +130,16 @@ services:
       - graphite
 
 volumes:
+  emqtt_data:
+  emqtt_etc:
+  emqtt_lib:
+  emqtt_log:
   graphite:
   graphite_conf:
   grafana:
-  mosca:
-  redis:
   iot-data:
   influxdb:
 networks:
-  redis:
   graphite:
   broker:
   influxdb:


### PR DESCRIPTION
- Replaced Mosca with emqtt.
- Removed unused redis.

Default ACL: anybody can publish/subscribe anything except `$SYS/#` and `#` (literally).
AAA coming soon.