### PR TITLE
[libelium-backup]: Increased innodb-buffer-pool-size

### DIFF
--- a/projects/libelium-backup/stack.yml
+++ b/projects/libelium-backup/stack.yml
@@ -3,6 +3,7 @@ version: '3.1'
 services:
   mariadb:
     image: mariadb
+    command: mysqld --innodb-buffer-pool-size=4G
     environment:
       MYSQL_ROOT_PASSWORD: DgPTGyhM8ukkqTJ9
     volumes:


### PR DESCRIPTION
The default is just 256MB and it does not work well for us.