### PR TITLE
[IOT-CLOUD]: Updated map to match live version

### DIFF
--- a/projects/iot-cloud/software/mqtt-to-graphite/config/map
+++ b/projects/iot-cloud/software/mqtt-to-graphite/config/map
@@ -49,8 +49,6 @@ j meshliumf958/#
 j meshliumfa30/#
 j verbund/ST1
 j citisim/raspberry/IoanaPiZero
-# Ioana rpib moved from citisim to odsi
-j odsi/raspberry/Temperature
 j citisim/pycom/ST1
 j seaforest/raspberrypi/ST1
 j lora/#


### PR DESCRIPTION
Removed a redundant subscription which is not on the live image of mqtt2graphite.